### PR TITLE
Fix: prevent dimension dropping when a single centroid is used

### DIFF
--- a/R/corto.R
+++ b/R/corto.R
@@ -116,7 +116,7 @@ corto<-function(inmat,centroids,nbootstraps=100,p=1E-30,nthreads=1,verbose=FALSE
     message("Initial testing of triplets for DPI")
   }
   # Remove edges which have no TF
-  filtered<-sigedges[sigedges[,1]%in%centroids,]
+  filtered<-sigedges[sigedges[,1]%in%centroids, , drop=FALSE]
   rm(sigedges)
   filtered[,1]<-as.character(filtered[,1])
   filtered[,2]<-as.character(filtered[,2])
@@ -194,8 +194,8 @@ corto<-function(inmat,centroids,nbootstraps=100,p=1E-30,nthreads=1,verbose=FALSE
     targets<-setdiff(features,centroids)
 
     # Calculate centroid x target correlations
-    cenmat<-tmat[,centroids]
-    tarmat<-tmat[,targets]
+    cenmat<-tmat[,centroids, drop=FALSE]
+    tarmat<-tmat[,targets, drop=FALSE]
     cormat<-cor(cenmat,tarmat)
 
     # Extract significant correlations

--- a/R/functions.R
+++ b/R/functions.R
@@ -88,8 +88,8 @@ fcor<-function(inmat,centroids,r){
     targets<-setdiff(features,centroids)
 
     # Calculate centroid x target correlations
-    cenmat<-tmat[,centroids]
-    tarmat<-tmat[,targets]
+    cenmat<-tmat[,centroids, drop = FALSE]
+    tarmat<-tmat[,targets, drop = FALSE]
     cormat<-cor(cenmat,tarmat)
 
     # Extract significant correlations


### PR DESCRIPTION
Hello! This PR fixes a bug where providing a single gene as a centroid causes the internal matrix subsetting to drop to a vector. This led to rownames() returning NULL and subsequent "undefined columns selected" errors in the DPI calculation phase.

Changes:

Added drop = FALSE to matrix subsetting operations in fcor() and corto().

Ensured sigedges remains a valid data frame even with a single centroid.

Testing:
Verified with a single centroid input using load_all() and a test matrix. The function now correctly generates a regulon object for a single TF.